### PR TITLE
Flatten JSON in MathResult response body

### DIFF
--- a/src/main/java/calculation/service/MathResult.java
+++ b/src/main/java/calculation/service/MathResult.java
@@ -1,12 +1,17 @@
 package calculation.service;
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
 import java.util.UUID;
 
 /**
  * Created by mjkrumlauf on 10/16/16.
  */
 public class MathResult {
+
+    @JsonUnwrapped
     private MathOp mathOp;
+    
     private double result;
     private String id;
 


### PR DESCRIPTION
Flatten MathOp in MathResult JSON to make for cleaner response body.  The client doesn't need to know all about the internal structure of MathResult.